### PR TITLE
Remove unused history 'changes' attribute types, disable type checkin…

### DIFF
--- a/objetto/_applications.py
+++ b/objetto/_applications.py
@@ -803,7 +803,9 @@ class ApplicationInternals(Base):
                     from ._changes import Batch
 
                     atomic_batch_change = Batch(
-                        name=change.name, obj=obj, metadata={"atomic_change": change}
+                        name=change.name,
+                        obj=obj,
+                        metadata={"atomic_change": change, "is_atomic": True},
                     )
                     history.__enter_batch__(atomic_batch_change)
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.rst", "r") as fh:
 
 setuptools.setup(
     name="objetto",
-    version="1.5.3",
+    version="1.5.4",
     author="Bruno Nicko",
     author_email="brunonicko@gmail.com",
     description="Object-oriented framework for building smart applications and APIs",


### PR DESCRIPTION
Fixed:

  - Remove unused history 'changes' attribute types
  - Disable type checking for performance